### PR TITLE
Fix typo in german translation

### DIFF
--- a/res/src/commonMain/composeResources/values-de/strings.xml
+++ b/res/src/commonMain/composeResources/values-de/strings.xml
@@ -217,7 +217,7 @@
     <string name="action_navigate_debug_timeline">Öffne Debug Timeline</string>
     <string name="action_save">Speichern</string>
     <string name="action_notifications">Benachrichtigungen</string>
-    <string name="action_notifications_default">Standart</string>
+    <string name="action_notifications_default">Standard</string>
     <string name="action_notifications_all">Alle Nachrichten</string>
     <string name="action_notifications_mentions">Nur Erwähnungen</string>
     <string name="action_notifications_none">Keine</string>


### PR DESCRIPTION
This fixes a rather common typo where the german word `Standard` (translated from `default`) is written with a `t` not a `d`.

In case anyone needs proof: https://www.duden.de/haeufige_fehler/Standart