### PR TITLE
fix: use the thread root ID for navigation in context menu actions

### DIFF
--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRow.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRow.kt
@@ -75,7 +75,7 @@ fun EventRow(
     val roomPermissions = viewModel.roomPermissions.collectAsState().value
     WithContextMenu(
         focusId,
-        event.contextMenu(viewModel.sessionId, viewModel.roomId, roomPermissions, messageMetadata),
+        event.contextMenu(viewModel.sessionId, viewModel.roomId, roomPermissions, messageMetadata, viewModel.threadId),
     ) { openContextMenu ->
         Column(
             modifier

--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRowContextMenu.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRowContextMenu.kt
@@ -37,6 +37,7 @@ import chat.schildi.revenge.model.conversation.MessageMetadata
 import chat.schildi.revenge.preferences.value
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.core.ThreadId
 import io.element.android.libraries.matrix.api.timeline.item.EventThreadInfo
 import io.element.android.libraries.matrix.api.timeline.item.event.EventTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
@@ -70,6 +71,7 @@ fun EventTimelineItem.contextMenu(
     roomId: RoomId,
     permissions: ConversationPermissions?,
     messageMetadata: MessageMetadata?,
+    currentThreadId: ThreadId?,
 ): ImmutableList<ContextMenuEntry> {
     val messageContent = content as? MessageContent
     val showDevTools = ScPrefs.DEV_QUICK_OPTIONS.value()
@@ -114,7 +116,7 @@ fun EventTimelineItem.contextMenu(
             Action.Navigation.NavigateAuto,
             actionArgs = persistentListOf(DestinationEnum.ConversationThread.destName, sessionId.value, roomId.value, threadRootId ?: ""),
             keyboardShortcut = Key.T,
-        ).takeIf { threadRootId != null && messageContent != null },
+        ).takeIf { threadRootId != null && threadRootId != currentThreadId?.value && messageContent != null },
         ContextMenuActionEntry(
             Res.string.action_edit.toStringHolder(),
             rememberVectorPainter(Icons.Default.Edit),

--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRowContextMenu.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/conversation/event/EventRowContextMenu.kt
@@ -37,6 +37,7 @@ import chat.schildi.revenge.model.conversation.MessageMetadata
 import chat.schildi.revenge.preferences.value
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.SessionId
+import io.element.android.libraries.matrix.api.timeline.item.EventThreadInfo
 import io.element.android.libraries.matrix.api.timeline.item.event.EventTimelineItem
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageContent
 import io.element.android.libraries.matrix.api.timeline.item.event.MessageTypeWithAttachment
@@ -81,6 +82,7 @@ fun EventTimelineItem.contextMenu(
         permissions?.canRedactOther ?: false
     }
     val usesKeyboard = LocalInputModeManager.current.inputMode == InputMode.Keyboard
+    val threadRootId = (threadInfo() as? EventThreadInfo.ThreadResponse)?.threadRootId?.value ?: eventId?.value
     return listOfNotNull(
         ContextMenuActionEntry(
             Res.string.action_download_and_open.toStringHolder(),
@@ -110,9 +112,9 @@ fun EventTimelineItem.contextMenu(
             Res.string.action_thread.toStringHolder(),
             rememberVectorPainter(Icons.Default.Gesture),
             Action.Navigation.NavigateAuto,
-            actionArgs = persistentListOf(DestinationEnum.ConversationThread.destName, sessionId.value, roomId.value, eventId?.value ?: ""),
+            actionArgs = persistentListOf(DestinationEnum.ConversationThread.destName, sessionId.value, roomId.value, threadRootId ?: ""),
             keyboardShortcut = Key.T,
-        ).takeIf { eventId != null && messageContent != null },
+        ).takeIf { threadRootId != null && messageContent != null },
         ContextMenuActionEntry(
             Res.string.action_edit.toStringHolder(),
             rememberVectorPainter(Icons.Default.Edit),


### PR DESCRIPTION
I love the way you implemented threads in Schildi Revenge! I ran into a problem though: the thread icon on a message leads to the full thread, while the "Open thread" context menu entry only opens the single message.

### Steps to reproduce

1. Open a room containing a thread with several replies
2. Long-press one of the thread *replies* → "Open thread"
3. The thread opens without any of the preceding messages

Tapping the small thread icon on the same message opens the thread correctly, including all previous messages.

### Fix

Resolve the thread root the same way the rest of the code does, and use that for both the action argument and the visibility check:

```
val threadRootId = (threadInfo() as? EventThreadInfo.ThreadResponse)?.threadRootId?.value ?: eventId?.value
```

Behaviour after the change:

- Thread reply -> opens the thread it belongs to, same target as the thread icon
- Thread root / regular message -> its own event ID, unchanged from before
- Already inside a thread -> do not show the thread action in context menu