### PR TITLE
fix: multi-pane back navigation on android

### DIFF
--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/settings/SettingsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/settings/SettingsScreen.kt
@@ -39,6 +39,7 @@ import chat.schildi.revenge.Destination
 import chat.schildi.revenge.DestinationStateHolder
 import chat.schildi.revenge.Dimens
 import chat.schildi.revenge.LocalDestinationState
+import chat.schildi.revenge.NavigationPreference
 import chat.schildi.revenge.actions.FocusRole
 import chat.schildi.revenge.actions.ListActions
 import chat.schildi.revenge.actions.LocalKeyboardActionHandler
@@ -97,7 +98,7 @@ fun SettingsScreen(
                     .collectAsState(null).value != null
             }
             PlatformBackHandler(enabled = hasDetails) {
-                destination.details.navigate(Destination.MultiPaneSettingsPlaceholder)
+                destination.details.navigate(Destination.MultiPaneSettingsPlaceholder, NavigationPreference.REPLACE)
             }
             MultiPaneLayout(
                 outerDestination = destination.destinationId,

--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/split/ConversationDetailsMultiPaneScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/split/ConversationDetailsMultiPaneScreen.kt
@@ -13,6 +13,7 @@ import chat.schildi.revenge.Destination
 import chat.schildi.revenge.DestinationCategory
 import chat.schildi.revenge.DestinationStateHolder
 import chat.schildi.revenge.LocalDestinationState
+import chat.schildi.revenge.NavigationPreference
 import chat.schildi.revenge.compose.components.PlatformBackHandler
 import chat.schildi.revenge.config.keybindings.DestinationEnum
 
@@ -29,7 +30,7 @@ fun ConversationDetailsMultiPaneScreen(
             destination.details.state.collectAsState().value.destination !is Destination.MultiPaneRoomInfoPlaceholder
         val shouldHidePlaceholders = ScPrefs.HIDE_EMPTY_CONVERSATION_DETAILS_PANE.value()
         PlatformBackHandler(enabled = hasDetails) {
-            destination.details.navigate(Destination.MultiPaneRoomInfoPlaceholder)
+            destination.details.navigate(Destination.MultiPaneRoomInfoPlaceholder, NavigationPreference.REPLACE)
         }
         MultiPaneLayout(
             outerDestination = destination.destinationId,

--- a/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/split/InboxConversationMultiPaneScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/chat/schildi/revenge/compose/destination/split/InboxConversationMultiPaneScreen.kt
@@ -12,6 +12,7 @@ import chat.schildi.revenge.Destination
 import chat.schildi.revenge.DestinationCategory
 import chat.schildi.revenge.DestinationStateHolder
 import chat.schildi.revenge.LocalDestinationState
+import chat.schildi.revenge.NavigationPreference
 import chat.schildi.revenge.compose.components.PlatformBackHandler
 import chat.schildi.revenge.config.keybindings.DestinationEnum
 
@@ -28,7 +29,10 @@ fun InboxConversationMultiPaneScreen(
             destination.conversation.state.collectAsState().value.destination !is Destination.MultiPaneConversationPlaceholder
         val shouldHidePlaceholders = ScPrefs.HIDE_EMPTY_INBOX_PANE.value()
         PlatformBackHandler(enabled = hasConversation) {
-            destination.conversation.navigate(Destination.MultiPaneConversationPlaceholder)
+            destination.conversation.navigate(
+                Destination.MultiPaneConversationPlaceholder,
+                NavigationPreference.REPLACE,
+            )
         }
         MultiPaneLayout(
             outerDestination = destination.destinationId,


### PR DESCRIPTION
On Android, going back from a thread that was opened in the conversation details pane lands on an empty pane showing just the app icon, instead of returning to the conversation.

### Fix
  
Pass NavigationPreference.REPLACE explicitly in all three back handlers, matching what closeSplit, closeDestination and close in MultiPaneLayout.kt already do. Clearing a pane no longer depends on category coincidence. Where AUTO already picked the right branch, REPLACE runs the exact same navigateThis(), so inbox and settings behaviour is unchanged.