### PR TITLE
build(macos): Enable native DMG builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ For Windows releases:
 ./gradlew packageReleaseMsi
 ```
 
+For macOS releases:
+
+```
+./gradlew packageReleaseDmg
+```
+
 ## Running as Flatpak
 
 While there is no plan to release SchildiChat on Flathub for the moment, if you prefer to run it as a Flatpak you can use the

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -404,7 +404,7 @@ compose.desktop {
             targetFormats(
                 TargetFormat.Exe,
                 TargetFormat.Msi,
-                // TargetFormat.Dmg, // Needs Apple volunteers
+                TargetFormat.Dmg,
             )
             packageName = nativePackageName
             packageVersion = calVer
@@ -446,6 +446,14 @@ compose.desktop {
 
             macOS {
                 appCategory = "public.app-category.social-networking"
+                minimumSystemVersion = "11.0"
+
+                infoPlist {
+                    extraKeysRawXml = """
+                        <key>NSLocalNetworkUsageDescription</key>
+                        <string>SchildiChat Revenge can connect to Matrix homeservers on your local network.</string>
+                    """.trimIndent()
+                }
             }
         }
     }


### PR DESCRIPTION
Enable the Compose DMG target, declare the measured minimum macOS version, and provide the local network usage description needed for local Matrix homeservers. Document the matching Gradle build command.

Refs #31