### PR TITLE
feat(macos): Set social networking category

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -443,6 +443,10 @@ compose.desktop {
                 debMaintainer = "SpiritCroc <shire@spiritcroc.de>"
                 rpmLicenseType = "AGPL-3.0-only"
             }
+
+            macOS {
+                appCategory = "public.app-category.social-networking"
+            }
         }
     }
 }


### PR DESCRIPTION
Classify macOS application bundles as social networking applications.

Refs #31